### PR TITLE
Added runtime editing

### DIFF
--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/BottomSheetBuilder.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/BottomSheetBuilder.java
@@ -18,6 +18,7 @@ package com.github.rubensousa.bottomsheetbuilder;
 
 import android.content.Context;
 import android.os.Build;
+import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.MenuRes;
@@ -44,31 +45,11 @@ public class BottomSheetBuilder {
     public static final int MODE_LIST = 0;
     public static final int MODE_GRID = 1;
 
-    @DrawableRes
-    private int mBackgroundDrawable;
-
-    @ColorRes
-    private int mBackgroundColor;
-
-    @DrawableRes
-    private int mDividerBackground;
-
-    @DrawableRes
-    private int mItemBackground;
-
-    @ColorRes
-    private int mItemTextColor;
-
-    @ColorRes
-    private int mTitleTextColor;
-
     @StyleRes
     private int mTheme;
 
     private boolean mDelayedDismiss = true;
     private boolean mExpandOnStart = false;
-    private int mIconTintColor = -1;
-    private Menu mMenu;
     private BottomSheetAdapterBuilder mAdapterBuilder;
     private CoordinatorLayout mCoordinatorLayout;
     private AppBarLayout mAppBarLayout;
@@ -103,49 +84,48 @@ public class BottomSheetBuilder {
     }
 
     public BottomSheetBuilder setItemClickListener(BottomSheetItemClickListener listener) {
-        mItemClickListener = listener;
+        mAdapterBuilder.setItemClickListener(listener);
         return this;
     }
 
     public BottomSheetBuilder setMenu(@MenuRes int menu) {
-        mMenu = new MenuBuilder(mContext);
+        Menu mMenu = new MenuBuilder(mContext);
         new SupportMenuInflater(mContext).inflate(menu, mMenu);
         return setMenu(mMenu);
     }
 
     public BottomSheetBuilder setMenu(Menu menu) {
-        mMenu = menu;
-        mAdapterBuilder.setMenu(mMenu);
+        mAdapterBuilder.setMenu(menu);
         return this;
     }
 
     public BottomSheetBuilder setItemTextColor(@ColorRes int color) {
-        mItemTextColor = color;
+        mAdapterBuilder.setItemTextColor(color);
         return this;
     }
 
     public BottomSheetBuilder setTitleTextColor(@ColorRes int color) {
-        mTitleTextColor = color;
+        mAdapterBuilder.setTitleTextColor(color);
         return this;
     }
 
     public BottomSheetBuilder setBackground(@DrawableRes int background) {
-        mBackgroundDrawable = background;
+        mAdapterBuilder.setBackground(background);
         return this;
     }
 
     public BottomSheetBuilder setBackgroundColor(@ColorRes int background) {
-        mBackgroundColor = background;
+        mAdapterBuilder.setBackgroundColor(background);
         return this;
     }
 
     public BottomSheetBuilder setDividerBackground(@DrawableRes int background) {
-        mDividerBackground = background;
+        mAdapterBuilder.setDividerBackground(background);
         return this;
     }
 
     public BottomSheetBuilder setItemBackground(@DrawableRes int background) {
-        mItemBackground = background;
+        mAdapterBuilder.setItemBackground(background);
         return this;
     }
 
@@ -165,30 +145,27 @@ public class BottomSheetBuilder {
     }
 
     public BottomSheetBuilder setIconTintColorResource(@ColorRes int color) {
-        mIconTintColor = ContextCompat.getColor(mContext, color);
+        mAdapterBuilder.setIconTintColorResource(color);
         return this;
     }
 
-    public BottomSheetBuilder setIconTintColor(int color) {
-        mIconTintColor = color;
+    public BottomSheetBuilder setIconTintColor(@ColorInt int color) {
+        mAdapterBuilder.setIconTintColor(color);
         return this;
     }
 
-    public View createView() {
+    public BottomSheetBuilder setEditorEnabled(boolean editorEnabled) {
+        mAdapterBuilder.setEditorEnabled(editorEnabled);
+        return this;
+    }
 
-        if (mMenu == null) {
-            throw new IllegalStateException("You need to provide at least one Menu" +
-                    "or a Menu resource id");
-        }
-
+    public BottomSheetView createView() {
         if (mCoordinatorLayout == null) {
             throw new IllegalStateException("You need to provide a coordinatorLayout" +
                     "so the view can be placed on it");
         }
 
-        View sheet = mAdapterBuilder.createView(mItemTextColor, mTitleTextColor,
-                mBackgroundDrawable, mBackgroundColor, mDividerBackground, mItemBackground,
-                mIconTintColor, mItemClickListener);
+        BottomSheetView sheet = mAdapterBuilder.createView();
 
         ViewCompat.setElevation(sheet, mContext.getResources()
                 .getDimensionPixelSize(R.dimen.bottomsheet_elevation));
@@ -215,19 +192,13 @@ public class BottomSheetBuilder {
     }
 
     public BottomSheetMenuDialog createDialog() {
-
-        if (mMenu == null) {
-            throw new IllegalStateException("You need to provide at least one Menu" +
-                    "or a Menu resource id");
-        }
-
         BottomSheetMenuDialog dialog = mTheme == 0
                 ? new BottomSheetMenuDialog(mContext, R.style.BottomSheetBuilder_DialogStyle)
                 : new BottomSheetMenuDialog(mContext, mTheme);
 
-        View sheet = mAdapterBuilder.createView(mItemTextColor, mTitleTextColor,
-                mBackgroundDrawable, mBackgroundColor, mDividerBackground, mItemBackground,
-                mIconTintColor, dialog);
+        setItemClickListener(dialog);
+
+        View sheet = mAdapterBuilder.createView();
 
         sheet.findViewById(R.id.fakeShadow).setVisibility(View.GONE);
         dialog.setAppBar(mAppBarLayout);

--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/BottomSheetBuilder.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/BottomSheetBuilder.java
@@ -26,7 +26,6 @@ import android.support.annotation.StyleRes;
 import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.BottomSheetBehavior;
 import android.support.design.widget.CoordinatorLayout;
-import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewCompat;
 import android.support.v7.view.SupportMenuInflater;
 import android.support.v7.view.menu.MenuBuilder;
@@ -37,6 +36,7 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
 import com.github.rubensousa.bottomsheetbuilder.adapter.BottomSheetAdapterBuilder;
+import com.github.rubensousa.bottomsheetbuilder.adapter.BottomSheetColors;
 import com.github.rubensousa.bottomsheetbuilder.adapter.BottomSheetItemClickListener;
 
 
@@ -47,6 +47,8 @@ public class BottomSheetBuilder {
 
     @StyleRes
     private int mTheme;
+
+    private BottomSheetColors mColors;
 
     private boolean mDelayedDismiss = true;
     private boolean mExpandOnStart = false;
@@ -59,7 +61,8 @@ public class BottomSheetBuilder {
     public BottomSheetBuilder(Context context, CoordinatorLayout coordinatorLayout) {
         mContext = context;
         mCoordinatorLayout = coordinatorLayout;
-        mAdapterBuilder = new BottomSheetAdapterBuilder(mContext);
+        mColors=new BottomSheetColors(mContext);
+        mAdapterBuilder = new BottomSheetAdapterBuilder(mContext,mColors);
     }
 
     public BottomSheetBuilder(Context context) {
@@ -69,7 +72,8 @@ public class BottomSheetBuilder {
     public BottomSheetBuilder(Context context, @StyleRes int theme) {
         mContext = context;
         mTheme = theme;
-        mAdapterBuilder = new BottomSheetAdapterBuilder(mContext);
+        mColors=new BottomSheetColors(context);
+        mAdapterBuilder = new BottomSheetAdapterBuilder(mContext, mColors);
     }
 
     public BottomSheetBuilder setMode(int mode) {
@@ -99,33 +103,39 @@ public class BottomSheetBuilder {
         return this;
     }
 
+    public BottomSheetBuilder setColors(BottomSheetColors colors) {
+        mColors=colors;
+        mAdapterBuilder.setColors(mColors);
+        return this;
+    }
+
     public BottomSheetBuilder setItemTextColor(@ColorRes int color) {
-        mAdapterBuilder.setItemTextColor(color);
+        mColors.setItemTextColorRes(color);
         return this;
     }
 
     public BottomSheetBuilder setTitleTextColor(@ColorRes int color) {
-        mAdapterBuilder.setTitleTextColor(color);
+        mColors.setTitleTextColorRes(color);
         return this;
     }
 
     public BottomSheetBuilder setBackground(@DrawableRes int background) {
-        mAdapterBuilder.setBackground(background);
+        mColors.setBackground(background);
         return this;
     }
 
     public BottomSheetBuilder setBackgroundColor(@ColorRes int background) {
-        mAdapterBuilder.setBackgroundColor(background);
+        mColors.setBackgroundColorRes(background);
         return this;
     }
 
     public BottomSheetBuilder setDividerBackground(@DrawableRes int background) {
-        mAdapterBuilder.setDividerBackground(background);
+        mColors.setDividerBackground(background);
         return this;
     }
 
     public BottomSheetBuilder setItemBackground(@DrawableRes int background) {
-        mAdapterBuilder.setItemBackground(background);
+        mColors.setItemBackground(background);
         return this;
     }
 
@@ -145,12 +155,12 @@ public class BottomSheetBuilder {
     }
 
     public BottomSheetBuilder setIconTintColorResource(@ColorRes int color) {
-        mAdapterBuilder.setIconTintColorResource(color);
+        mColors.setIconTintColorRes(color);
         return this;
     }
 
     public BottomSheetBuilder setIconTintColor(@ColorInt int color) {
-        mAdapterBuilder.setIconTintColor(color);
+        mColors.setIconTintColor(color);
         return this;
     }
 

--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/BottomSheetView.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/BottomSheetView.java
@@ -7,7 +7,10 @@ import android.support.design.widget.CoordinatorLayout;
 import android.view.LayoutInflater;
 import android.widget.LinearLayout;
 
+import com.github.rubensousa.bottomsheetbuilder.adapter.BottomSheetColors;
 import com.github.rubensousa.bottomsheetbuilder.adapter.BottomSheetEditor;
+
+import java.io.Serializable;
 
 public class BottomSheetView extends LinearLayout {
     private BottomSheetEditor mEditor;
@@ -38,5 +41,4 @@ public class BottomSheetView extends LinearLayout {
         if (mEditor==null) throw new IllegalStateException("Editor is not enabled for this view.");
         return mEditor;
     }
-
 }

--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/BottomSheetView.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/BottomSheetView.java
@@ -1,0 +1,42 @@
+package com.github.rubensousa.bottomsheetbuilder;
+
+import android.content.Context;
+import android.support.annotation.LayoutRes;
+import android.support.design.widget.BottomSheetBehavior;
+import android.support.design.widget.CoordinatorLayout;
+import android.view.LayoutInflater;
+import android.widget.LinearLayout;
+
+import com.github.rubensousa.bottomsheetbuilder.adapter.BottomSheetEditor;
+
+public class BottomSheetView extends LinearLayout {
+    private BottomSheetEditor mEditor;
+
+
+    public BottomSheetView(Context context) {
+        super(context);
+    }
+
+    public BottomSheetView(Context context,BottomSheetEditor editor) {
+        super(context);
+        mEditor=editor;
+    }
+
+    public static BottomSheetView from(Context context,@LayoutRes int layout,BottomSheetEditor editor) {
+        BottomSheetView view=new BottomSheetView(context);
+        view.mEditor=editor;
+        LayoutInflater.from(context).inflate(layout,view);
+        return view;
+    };
+
+    public BottomSheetBehavior getBehavior() {
+        CoordinatorLayout.LayoutParams params= (CoordinatorLayout.LayoutParams) getLayoutParams();
+        return ((BottomSheetBehavior) params.getBehavior());
+    }
+
+    public BottomSheetEditor getEditor() {
+        if (mEditor==null) throw new IllegalStateException("Editor is not enabled for this view.");
+        return mEditor;
+    }
+
+}

--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetAdapterBuilder.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetAdapterBuilder.java
@@ -19,11 +19,12 @@ package com.github.rubensousa.bottomsheetbuilder.adapter;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.view.menu.MenuItemImpl;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
@@ -31,12 +32,10 @@ import android.support.v7.widget.RecyclerView;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.SubMenu;
-import android.widget.LinearLayout;
 
 import com.github.rubensousa.bottomsheetbuilder.BottomSheetBuilder;
 import com.github.rubensousa.bottomsheetbuilder.R;
 
-import com.github.rubensousa.bottomsheetbuilder.BottomSheetBuilder;
 import com.github.rubensousa.bottomsheetbuilder.BottomSheetView;
 
 import java.util.ArrayList;
@@ -44,26 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 
 public class BottomSheetAdapterBuilder {
-    @DrawableRes
-    private int mBackgroundDrawable;
-
-    @ColorRes
-    private int mBackgroundColor;
-
-    @DrawableRes
-    private int mDividerBackground;
-
-    @DrawableRes
-    private int mItemBackground;
-
-    @ColorRes
-    private int mItemTextColor;
-
-    @ColorRes
-    private int mTitleTextColor;
-
-    @ColorRes
-    private int mIconTintColor = -1;
+    private BottomSheetColors mColors;
 
     private BottomSheetItemClickListener mItemClickListener;
 
@@ -81,8 +61,9 @@ public class BottomSheetAdapterBuilder {
 
     private List<BottomSheetItem> mItems;
 
-    public BottomSheetAdapterBuilder(Context context) {
+    public BottomSheetAdapterBuilder(Context context, BottomSheetColors colors) {
         mContext = context;
+        mColors=colors;
     }
 
     public void setMenu(Menu menu) {
@@ -115,13 +96,15 @@ public class BottomSheetAdapterBuilder {
         recyclerView.setHasFixedSize(true);
         recyclerView.setItemAnimator(new DefaultItemAnimator());
 
-        if (mBackgroundDrawable != 0) {
-            recyclerView.setBackgroundResource(mBackgroundDrawable);
-        } else {
-            if (mBackgroundColor != 0) {
-                recyclerView.setBackgroundColor(ContextCompat.getColor(mContext, mBackgroundColor));
+        if (mColors.getBackground() != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                recyclerView.setBackground(mColors.getBackground());
             }
-        }
+            else
+                //noinspection deprecation
+                recyclerView.setBackgroundDrawable(mColors.getBackground());
+        } else
+                recyclerView.setBackgroundColor(mColors.getBackgroundColor());
 
         mItems = createAdapterItems();
 
@@ -210,15 +193,15 @@ public class BottomSheetAdapterBuilder {
                 for (int j = 0; j < subMenu.size(); j++) {
                     MenuItem subItem = subMenu.getItem(j);
                     if (subItem.isVisible()) {
-                        toAdd=new BottomSheetMenuItem(subItem, mItemTextColor,
-                                mItemBackground, mIconTintColor);
+                        toAdd=new BottomSheetMenuItem(subItem, mColors.getItemTextColor(),
+                                mColors.getItemBackground(), mColors.getIconTintColor());
                         mItems.add(toPosition++,toAdd);
                         binds.add(specificPos++,toAdd);
                         mAddedSubMenu = true;
                     }
                 }
             } else {
-                toAdd=new BottomSheetMenuItem(item, mItemTextColor, mItemBackground, mIconTintColor);
+                toAdd=new BottomSheetMenuItem(item, mColors.getItemTextColor(), mColors.getItemBackground(), mColors.getIconTintColor());
                 mItems.add(toPosition,toAdd);
                 binds.add(specificPos,toAdd);
             }
@@ -226,13 +209,13 @@ public class BottomSheetAdapterBuilder {
     }
 
     void addHeader(CharSequence title,int itemsPos,int bindsPos, List<BottomSheetItem> binds) {
-        BottomSheetItem toAdd=new BottomSheetHeader(title.toString(), mTitleTextColor);
+        BottomSheetItem toAdd=new BottomSheetHeader(title.toString(), mColors.getTitleTextColor());
         mItems.add(itemsPos,toAdd);
         binds.add(bindsPos,toAdd);
     }
 
     void addDivider(int itemsPos,int bindsPos, List<BottomSheetItem> binds) {
-        BottomSheetItem toAdd=new BottomSheetDivider(mDividerBackground);
+        BottomSheetItem toAdd=new BottomSheetDivider(mColors.getDividerBackground());
         mItems.add(itemsPos,toAdd);
         binds.add(bindsPos,toAdd);
     }
@@ -241,76 +224,18 @@ public class BottomSheetAdapterBuilder {
         return mAddedSubMenu;
     }
 
-    public void setItemTextColor(int itemTextColor) {
-        this.mItemTextColor = itemTextColor;
-    }
-
-    public void setItemClickListener(BottomSheetItemClickListener itemClickListener) {
-        mItemClickListener = itemClickListener;
-    }
-
-    public void setTitleTextColor(int titleTextColor) {
-        mTitleTextColor = titleTextColor;
-    }
-
-    public void setBackground(int background) {
-        mBackgroundDrawable = background;
-    }
-
-    public void setBackgroundColor(int backgroundColor) {
-        mBackgroundColor = backgroundColor;
-    }
-
-    public void setDividerBackground(int dividerBackground) {
-        mDividerBackground = dividerBackground;
-    }
-
-    public void setItemBackground(int itemBackground) {
-        mItemBackground = itemBackground;
-    }
-
-    public void setIconTintColorResource(int iconTintColorResource) {
-        mIconTintColor = iconTintColorResource;
-    }
-
-    public void setIconTintColor(int iconTintColor) {
-        mIconTintColor = iconTintColor;
-    }
-
     HashMap<MenuItem, List<BottomSheetItem>> getBinds() {
         return mBinds;
     }
 
-    int getBackgroundDrawable() {
-        return mBackgroundDrawable;
-    }
-
-    int getBackgroundColor() {
-        return mBackgroundColor;
-    }
-
-    int getDividerBackground() {
-        return mDividerBackground;
-    }
-
-    int getItemBackground() {
-        return mItemBackground;
-    }
-
-    int getItemTextColor() {
-        return mItemTextColor;
-    }
-
-    int getTitleTextColor() {
-        return mTitleTextColor;
-    }
-
-    int getIconTintColor() {
-        return mIconTintColor;
-    }
 
     BottomSheetItemClickListener getItemClickListener() {
         return mItemClickListener;
+    }
+
+
+    public void setItemClickListener(BottomSheetItemClickListener itemClickListener) {
+        mItemClickListener = itemClickListener;
     }
 
     int getMode() {
@@ -327,5 +252,13 @@ public class BottomSheetAdapterBuilder {
 
     public void setEditorEnabled(boolean editorEnabled) {
         mEditorEnabled = editorEnabled;
+    }
+
+    public void setColors(BottomSheetColors colors) {
+        mColors = colors;
+    }
+
+    public BottomSheetColors getColors() {
+        return mColors;
     }
 }

--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetAdapterBuilder.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetAdapterBuilder.java
@@ -123,14 +123,14 @@ public class BottomSheetAdapterBuilder {
             }
         }
 
-        List<BottomSheetItem> items = createAdapterItems();
+        mItems = createAdapterItems();
 
-        final BottomSheetItemAdapter adapter = new BottomSheetItemAdapter(items, mMode,
+        final BottomSheetItemAdapter adapter = new BottomSheetItemAdapter(mItems, mMode,
                 mItemClickListener);
 
         if (editor!=null) {
             editor.setAdapter(adapter);
-            editor.setItems(items);
+            editor.setItems(mItems);
             editor.setRecycler(recyclerView);
         }
 

--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetAdapterBuilder.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetAdapterBuilder.java
@@ -19,27 +19,67 @@ package com.github.rubensousa.bottomsheetbuilder.adapter;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.support.annotation.ColorInt;
+import android.support.annotation.ColorRes;
+import android.support.annotation.DrawableRes;
 import android.support.v4.content.ContextCompat;
+import android.support.v7.view.menu.MenuItemImpl;
+import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.SubMenu;
-import android.view.View;
+import android.widget.LinearLayout;
 
 import com.github.rubensousa.bottomsheetbuilder.BottomSheetBuilder;
 import com.github.rubensousa.bottomsheetbuilder.R;
 
+import com.github.rubensousa.bottomsheetbuilder.BottomSheetBuilder;
+import com.github.rubensousa.bottomsheetbuilder.BottomSheetView;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public class BottomSheetAdapterBuilder {
+    @DrawableRes
+    private int mBackgroundDrawable;
+
+    @ColorRes
+    private int mBackgroundColor;
+
+    @DrawableRes
+    private int mDividerBackground;
+
+    @DrawableRes
+    private int mItemBackground;
+
+    @ColorRes
+    private int mItemTextColor;
+
+    @ColorRes
+    private int mTitleTextColor;
+
+    @ColorRes
+    private int mIconTintColor = -1;
+
+    private BottomSheetItemClickListener mItemClickListener;
 
     private int mMode;
     private Menu mMenu;
     private Context mContext;
+    private boolean mEditorEnabled=false;
+
+    void setAddedSubMenu(boolean addedSubMenu) {
+        mAddedSubMenu = addedSubMenu;
+    }
+
+    private boolean mAddedSubMenu;
+    private HashMap<MenuItem,List<BottomSheetItem>> mBinds;
+
+    private List<BottomSheetItem> mItems;
 
     public BottomSheetAdapterBuilder(Context context) {
         mContext = context;

--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetColors.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetColors.java
@@ -2,24 +2,41 @@ package com.github.rubensousa.bottomsheetbuilder.adapter;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
 import android.support.v4.content.ContextCompat;
 
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.io.Serializable;
 
 public class BottomSheetColors implements Serializable {
+    private transient Context mContext;
+    private transient Drawable mBackgroundDrawable;
 
-    private final Context mContext;
-    private Drawable mBackgroundDrawable;
+    private String mBackgroundUri;
+
+    @DrawableRes
+    private int mBackgroundRes;
 
     @ColorInt
     private int mBackgroundColor;
 
-    private Drawable mDividerBackgroundDrawable;
+    private transient Drawable mDividerBackgroundDrawable;
 
-    private Drawable mItemBackgroundDrawable;
+    private transient Drawable mItemBackgroundDrawable;
+
+    private String mDividerBackgroundUri;
+
+    private String mItemBackgroundUri;
+
+    @DrawableRes
+    private int mDividerBackgroundRes;
+
+    @DrawableRes
+    private int mItemBackgroundRes;
 
     @ColorInt
     private int mItemTextColor;
@@ -51,7 +68,11 @@ public class BottomSheetColors implements Serializable {
     }
 
     public void setBackground(@DrawableRes int background) {
-        mBackgroundDrawable = ContextCompat.getDrawable(mContext,background);
+        mBackgroundRes=background;
+    }
+
+    public void setBackground(Uri background) {
+        mBackgroundUri=background.toString();
     }
 
     public void setBackground(Drawable background) {
@@ -67,7 +88,11 @@ public class BottomSheetColors implements Serializable {
     }
 
     public void setDividerBackground(@DrawableRes int dividerBackground) {
-        mDividerBackgroundDrawable = ContextCompat.getDrawable(mContext,dividerBackground);
+        mDividerBackgroundRes = dividerBackground;
+    }
+
+    public void setDividerBackground(Uri dividerBackground) {
+        mDividerBackgroundUri = dividerBackground.toString();
     }
 
     public void setDividerBackground(Drawable dividerBackground) {
@@ -75,7 +100,11 @@ public class BottomSheetColors implements Serializable {
     }
 
     public void setItemBackground(@DrawableRes int itemBackground) {
-        mItemBackgroundDrawable = ContextCompat.getDrawable(mContext,itemBackground);
+        mItemBackgroundRes = itemBackground;
+    }
+
+    public void setItemBackground(Uri itemBackground) {
+        mItemBackgroundUri = itemBackground.toString();
     }
 
     public void setItemBackground(Drawable itemBackground) {
@@ -91,24 +120,48 @@ public class BottomSheetColors implements Serializable {
     }
 
 
-    @ColorInt int getBackgroundColor() {
+    public @ColorInt int getBackgroundColor() {
         return mBackgroundColor;
     }
 
-    Drawable getDividerBackground() {
-        return mDividerBackgroundDrawable;
+    public Drawable getDividerBackground() {
+        if (mDividerBackgroundDrawable!=null)
+            return mDividerBackgroundDrawable;
+        else if (mDividerBackgroundRes!=0)
+            return ContextCompat.getDrawable(mContext,mDividerBackgroundRes);
+        else if (mDividerBackgroundUri!=null)
+            return getDrawableFromUri(mContext,Uri.parse(mDividerBackgroundUri));
+        else
+            return null;
     }
 
-
-    Drawable getItemBackground() {
-        return mItemBackgroundDrawable;
+    public void setContext(Context context) {
+        mContext=context;
     }
 
-    Drawable getBackground() {
-        return mBackgroundDrawable;
+    public Drawable getItemBackground() {
+        if (mItemBackgroundDrawable!=null)
+            return mItemBackgroundDrawable;
+        else if (mItemBackgroundRes!=0)
+            return ContextCompat.getDrawable(mContext,mItemBackgroundRes);
+        else if (mItemBackgroundUri!=null)
+            return getDrawableFromUri(mContext,Uri.parse(mItemBackgroundUri));
+        else
+            return null;
     }
 
-    @ColorInt int getItemTextColor() {
+    public Drawable getBackground() {
+        if (mBackgroundDrawable!=null)
+            return mBackgroundDrawable;
+        else if (mBackgroundRes!=0)
+            return ContextCompat.getDrawable(mContext,mBackgroundRes);
+        else if (mBackgroundUri!=null)
+            return getDrawableFromUri(mContext,Uri.parse(mBackgroundUri));
+        else
+            return null;
+    }
+
+    public @ColorInt int getItemTextColor() {
         return mItemTextColor;
     }
 
@@ -120,4 +173,19 @@ public class BottomSheetColors implements Serializable {
     @ColorInt int getIconTintColor() {
         return mIconTintColor;
     }
+
+
+    private Drawable getDrawableFromUri(Context context,Uri uri) {
+        if (context==null)
+            throw new IllegalStateException("Call setContext after deserialization.");
+        Drawable newDrawable;
+        try {
+            InputStream inputStream = context.getContentResolver().openInputStream(uri);
+            newDrawable = Drawable.createFromStream(inputStream, uri.toString() );
+        } catch (FileNotFoundException e) {
+            newDrawable = null;
+        }
+        return newDrawable;
+    }
+
 }

--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetColors.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetColors.java
@@ -1,0 +1,123 @@
+package com.github.rubensousa.bottomsheetbuilder.adapter;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.ColorInt;
+import android.support.annotation.ColorRes;
+import android.support.annotation.DrawableRes;
+import android.support.v4.content.ContextCompat;
+
+import java.io.Serializable;
+
+public class BottomSheetColors implements Serializable {
+
+    private final Context mContext;
+    private Drawable mBackgroundDrawable;
+
+    @ColorInt
+    private int mBackgroundColor;
+
+    private Drawable mDividerBackgroundDrawable;
+
+    private Drawable mItemBackgroundDrawable;
+
+    @ColorInt
+    private int mItemTextColor;
+
+    @ColorInt
+    private int mTitleTextColor;
+
+    @ColorInt
+    private int mIconTintColor=-1;
+
+    public BottomSheetColors(Context context) {
+        mContext=context;
+    }
+
+    public void setItemTextColorRes(@ColorRes int itemTextColor) {
+        mItemTextColor = ContextCompat.getColor(mContext,itemTextColor);
+    }
+
+    public void setItemTextColor(@ColorInt int itemTextColor) {
+        mItemTextColor = itemTextColor;
+    }
+
+    public void setTitleTextColorRes(@ColorRes int titleTextColor) {
+        mTitleTextColor = ContextCompat.getColor(mContext,titleTextColor);;
+    }
+
+    public void setTitleTextColor(@ColorInt int titleTextColor) {
+        mTitleTextColor = titleTextColor;
+    }
+
+    public void setBackground(@DrawableRes int background) {
+        mBackgroundDrawable = ContextCompat.getDrawable(mContext,background);
+    }
+
+    public void setBackground(Drawable background) {
+        mBackgroundDrawable = background;
+    }
+
+    public void setBackgroundColorRes(@ColorRes int backgroundColor) {
+        mBackgroundColor = ContextCompat.getColor(mContext,backgroundColor);;
+    }
+
+    public void setBackgroundColor(@ColorInt int backgroundColor) {
+        mBackgroundColor = backgroundColor;
+    }
+
+    public void setDividerBackground(@DrawableRes int dividerBackground) {
+        mDividerBackgroundDrawable = ContextCompat.getDrawable(mContext,dividerBackground);
+    }
+
+    public void setDividerBackground(Drawable dividerBackground) {
+        mDividerBackgroundDrawable = dividerBackground;
+    }
+
+    public void setItemBackground(@DrawableRes int itemBackground) {
+        mItemBackgroundDrawable = ContextCompat.getDrawable(mContext,itemBackground);
+    }
+
+    public void setItemBackground(Drawable itemBackground) {
+        mItemBackgroundDrawable = itemBackground;
+    }
+
+    public void setIconTintColorRes(@ColorRes int iconTintColor) {
+        mIconTintColor = ContextCompat.getColor(mContext,iconTintColor);
+    }
+
+    public void setIconTintColor(@ColorInt int iconTintColor) {
+        mIconTintColor = iconTintColor;
+    }
+
+
+    @ColorInt int getBackgroundColor() {
+        return mBackgroundColor;
+    }
+
+    Drawable getDividerBackground() {
+        return mDividerBackgroundDrawable;
+    }
+
+
+    Drawable getItemBackground() {
+        return mItemBackgroundDrawable;
+    }
+
+    Drawable getBackground() {
+        return mBackgroundDrawable;
+    }
+
+    @ColorInt int getItemTextColor() {
+        return mItemTextColor;
+    }
+
+
+    @ColorInt int getTitleTextColor() {
+        return mTitleTextColor;
+    }
+
+    @ColorInt int getIconTintColor() {
+        return mIconTintColor;
+    }
+}

--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetDivider.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetDivider.java
@@ -17,20 +17,19 @@
 package com.github.rubensousa.bottomsheetbuilder.adapter;
 
 
+import android.graphics.drawable.Drawable;
 import android.support.annotation.DrawableRes;
 
 
 class BottomSheetDivider implements BottomSheetItem {
 
-    @DrawableRes
-    private int mBackgroundDrawable;
+    private Drawable mBackgroundDrawable;
 
-    public BottomSheetDivider(@DrawableRes int background) {
+    public BottomSheetDivider(Drawable background) {
         mBackgroundDrawable = background;
     }
 
-    @DrawableRes
-    public int getBackground() {
+    public Drawable getBackground() {
         return mBackgroundDrawable;
     }
 

--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetEditor.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetEditor.java
@@ -8,6 +8,7 @@ import android.view.SubMenu;
 
 import com.github.rubensousa.bottomsheetbuilder.BottomSheetBuilder;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -306,6 +307,14 @@ public class BottomSheetEditor {
 
     public Menu getMenu() {
         return mMenu;
+    }
+
+    public BottomSheetColors getColors() {
+        return mBuilder.getColors();
+    }
+
+    public int getMode() {
+        return mBuilder.getMode();
     }
 
     /*

--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetEditor.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetEditor.java
@@ -1,0 +1,350 @@
+package com.github.rubensousa.bottomsheetbuilder.adapter;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.SubMenu;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public class BottomSheetEditor {
+    private List<BottomSheetItem> mItems;
+    private HashMap<MenuItem,List<BottomSheetItem>> mBinds;
+    private BottomSheetAdapterBuilder mBuilder;
+    private BottomSheetItemAdapter mAdapter;
+    private RecyclerView mRecyclerView;
+    private Menu mMenu;
+    private boolean searchIsSubItemFlag;
+    private MenuItem searchMenuItem;
+    private int searchResultItemsPos;
+    private int searchResultBindsOffsetPos;
+
+
+    public BottomSheetEditor(BottomSheetAdapterBuilder builder) {
+        mBuilder=builder;
+        mBinds=builder.getBinds();
+        mItems=builder.getItems();
+        mMenu=builder.getMenu();
+    }
+
+    void setItems(List<BottomSheetItem> items) {
+        mItems=items;
+    }
+
+    void setAdapter(BottomSheetItemAdapter adapter) {
+        mAdapter=adapter;
+    }
+
+    void setRecycler(RecyclerView recycler) {
+        mRecyclerView = recycler;
+    }
+
+    public void setBottomSheetFixedSize(boolean fixedSize) {
+        mRecyclerView.setHasFixedSize(fixedSize);
+    }
+
+    public void changeItem(MenuItem item) {
+        changeItem(item,true);
+    }
+
+    private void changeItem(MenuItem item,boolean notify) {
+        MenuItem menu=getMenuItemWithSameID(item,true);
+        if (menu==null)
+            throw new NoSuchElementException("Item is not found in menu tree.");
+        else {
+            boolean isTitleNewEmpty=item.getTitle()==null || item.getTitle()=="";
+
+            //in case title cannot be empty
+            /*if (isTitleNewEmpty) {
+                if (!menu.hasSubMenu() && !searchIsSubItemFlag)
+                    throw new IllegalArgumentException("Menu must have a title, unless it has submenu.");
+                else if (searchIsSubItemFlag)
+                    throw new IllegalArgumentException("Submenu must have a title.");
+            */
+
+            menu.setTitle(item.getTitle());
+            menu.setIcon(item.getIcon());
+
+            if (searchResultBindsOffsetPos>=0) {
+                int oldPos=searchResultItemsPos+searchResultBindsOffsetPos;
+                mBinds.get(searchMenuItem).remove(searchResultBindsOffsetPos);
+                mItems.remove(oldPos);
+                //menu that has BottomSheetHeader title but now it shouldnt have
+                if (searchResultBindsOffsetPos==0 && !searchIsSubItemFlag && menu.hasSubMenu() && isTitleNewEmpty) {
+                    if (notify) mAdapter.notifyItemRemoved(oldPos);
+                } else {
+                    if (!searchIsSubItemFlag)
+                        mBuilder.addHeader(menu.getTitle(),oldPos,searchResultBindsOffsetPos,mBinds.get(menu));
+                    else
+                        mBuilder.addMenuItem(menu,Integer.MAX_VALUE,oldPos,mBinds.get(searchMenuItem),searchResultBindsOffsetPos);
+                        if (notify) mAdapter.notifyItemChanged(searchResultItemsPos);
+                    }
+            }
+            else if (!isTitleNewEmpty) {
+                int posToAdd=mBinds.get(menu).size()-menu.getSubMenu().size();
+                mBuilder.addHeader(menu.getTitle(),searchResultItemsPos+posToAdd,posToAdd,mBinds.get(menu));
+                if (notify) mAdapter.notifyItemChanged(searchResultItemsPos);
+            }
+        }
+    }
+
+
+    public void removeItem(MenuItem item) {
+        removeItem(item,true,true);
+    }
+
+    private void removeItem(MenuItem item,boolean notify,boolean removeFromMenu) {
+        if (getMenuItemWithSameID(item,false)!=null) {
+            int pos= getMenuItemPos(item);
+            removeItem(pos,notify,removeFromMenu);
+        }
+        else
+            //look for item in subMenus
+            for (MenuItem i:mBinds.keySet())
+                if (i.hasSubMenu()) {
+                    SubMenu j = i.getSubMenu();
+                    for (int k=0;k<j.size();++k)
+                        if (j.getItem(k).getItemId()==item.getItemId()) {
+                            //last submenu then remove the menu
+                            if (j.size()==1)
+                                removeItem(getMenuItemPos(i),notify,removeFromMenu);
+                            else {
+                                int posInBinds=getSubItemBindsPos(mBinds.get(i),k,j);
+                                int index=mItems.indexOf(mBinds.get(i).get(posInBinds));
+                                mItems.remove(index);
+                                mBinds.get(i).remove(posInBinds);
+                                if (removeFromMenu)
+                                    j.removeItem(j.getItem(k).getItemId());
+                                if (notify)
+                                    mAdapter.notifyItemRemoved(index);
+                            }
+                            return;
+                        }
+                }
+    }
+
+    private int getSubItemBindsPos(List<BottomSheetItem> bottomSheetItems, int posInSubMenu, SubMenu subMenu) {
+        return bottomSheetItems.size()-subMenu.size()+posInSubMenu;
+    }
+
+    private MenuItem getMenuItemWithSameID(MenuItem item,boolean searchSubMenus) {
+        for (MenuItem i:mBinds.keySet())
+            if (i.getItemId()==item.getItemId()) {
+                searchIsSubItemFlag=false;
+                if (i.hasSubMenu()) {
+                    searchResultItemsPos=findHeaderInSubMenu(mItems.indexOf(mBinds.get(i).get(0)),mBinds.get(i).size());
+                    searchResultBindsOffsetPos =searchResultItemsPos-mItems.indexOf(mBinds.get(i).get(0));
+                }
+                else {
+                    searchResultItemsPos=mItems.indexOf(mBinds.get(i).get(0));
+                    searchResultBindsOffsetPos=0;
+                }
+                searchMenuItem=i;
+                return i;
+            }
+            else if (i.hasSubMenu() && searchSubMenus) {
+                SubMenu j = i.getSubMenu();
+                for (int k=0;k<j.size();++k)
+                    if (j.getItem(k).getItemId()==item.getItemId()) {
+                        searchResultItemsPos=mItems.indexOf(mBinds.get(i).get(k))+mBinds.get(i).size()-j.size();
+                        searchIsSubItemFlag =true;
+                        searchResultBindsOffsetPos =searchResultItemsPos-mItems.indexOf(mBinds.get(i).get(0));
+                        searchMenuItem=i;
+                        return j.getItem(k);
+                    }
+            }
+        return null;
+    }
+
+    private int findHeaderInSubMenu(int posInItems, int size) {
+        for (int i=posInItems;i<posInItems+size;++i) {
+            if (mItems.get(i) instanceof BottomSheetHeader)
+                return i;
+        }
+        return -1;
+    }
+
+    private int getMenuItemPos(MenuItem item) {
+        int i=0;
+        while (i<mMenu.size() && mMenu.getItem(i++).getItemId()!=item.getItemId());
+
+        //item not found
+        if (--i==mMenu.size()-1)
+            return i;
+        else
+            return -1;
+    }
+
+
+    public void removeItem(int position) {
+        removeItem(position,true,true);
+    }
+
+    private void removeItem(int position,boolean notify,boolean removeFromMenu) {
+        MenuItem menuToBeRemoved=mMenu.getItem(position);
+        List<BottomSheetItem> itemsToBeRemoved=mBinds.get(menuToBeRemoved);
+        mBinds.remove(menuToBeRemoved);
+
+        int positionOfMenu=mItems.indexOf(itemsToBeRemoved.get(0));
+        int numberOfItemsToBeRemoved=itemsToBeRemoved.size();
+
+        for (BottomSheetItem i:itemsToBeRemoved) {
+            mItems.remove(i);
+        }
+
+        if (!hasSubMenuBefore(position) && mMenu.size()>position+1 && mMenu.getItem(position+1).hasSubMenu()) {
+            List<BottomSheetItem> list=mBinds.get(mMenu.getItem(position + 1));
+            if (list.get(0) instanceof BottomSheetDivider) {
+                BottomSheetItem item = list.remove(0);
+                mItems.remove(item);
+                numberOfItemsToBeRemoved++;
+            }
+        }
+        if (removeFromMenu) mMenu.removeItem(mMenu.getItem(position).getItemId());
+        if (notify) mAdapter.notifyItemRangeRemoved(positionOfMenu,numberOfItemsToBeRemoved);
+    }
+
+    public void addItem(MenuItem item,int position) {
+        addItem(item,position,true);
+    }
+
+    public void addItem(MenuItem item) {
+        addItem(item,mMenu.size());
+    }
+
+    private void addItem(MenuItem item,int position,boolean notify) {
+        if (hasSubMenuBefore(mMenu.size())) {
+            mBuilder.setAddedSubMenu(true);
+        }
+        else {
+            mBuilder.setAddedSubMenu(false);
+        }
+        //item.hasSubMenu - no sub-sub menus allowed
+        if (item.hasSubMenu() || position>=mMenu.size() || !mMenu.getItem(position).hasSubMenu()) {
+            //item will be placed at the end of menus
+
+            //new MenuItem has to be created
+            MenuItem newItem;
+            if (item.hasSubMenu()) {
+                mMenu.addSubMenu(item.getGroupId(), item.getItemId(), item.getOrder(), item.getTitle()).setIcon(item.getIcon());
+                newItem=mMenu.getItem(mMenu.size()-1);
+                inflateSubMenu(newItem.getSubMenu(),item.getSubMenu());
+            }
+            else
+                newItem=mMenu.add(item.getGroupId(),item.getItemId(),item.getOrder(),item.getTitle()).setIcon(item.getIcon());
+            int oldSize=mItems.size();
+            mBuilder.addMenuItem(newItem,mMenu.size(),mItems.size());
+            if (notify) mAdapter.notifyItemRangeInserted(oldSize,mItems.size()-oldSize);
+        }
+        else {
+            MenuItem newItem;
+            //item can be placed at the and of a submenu
+            newItem=mMenu.getItem(position).getSubMenu().add(item.getGroupId(),item.getItemId(),item.getOrder(),item.getTitle()).setIcon(item.getIcon());
+            int subMenuSize=mMenu.getItem(position).getSubMenu().size();
+            MenuItem subMenuItem=mMenu.getItem(position);
+
+            BottomSheetItem subMenuLastBottomSheetItem=mBinds.get(subMenuItem).get(mBinds.get(subMenuItem).size()-1);
+
+            int index = mItems.indexOf(subMenuLastBottomSheetItem)+1;
+            mBuilder.addMenuItem(newItem,position,index,mBinds.get(subMenuItem),-1);
+            if (notify) mAdapter.notifyItemInserted(mItems.indexOf(subMenuLastBottomSheetItem)+1);
+        }
+    }
+
+    private boolean hasSubMenuBefore(int position) {
+        if (mMenu.size()>=position || position<=0) {
+            for (int i=0;i<position;++i) {
+                if (mMenu.getItem(i).hasSubMenu())
+                    return true;
+            }
+            return false;
+        }
+        else
+            return false;
+    }
+
+    private void inflateSubMenu(SubMenu subMenuToBeInflated, SubMenu subMenu) {
+        for (int i=0;i<subMenu.size();++i) {
+            MenuItem item=subMenu.getItem(i);
+            subMenuToBeInflated.add(item.getGroupId(),item.getItemId(),item.getOrder(),item.getTitle()).setIcon(item.getIcon());
+        }
+    }
+
+    public Menu getMenu() {
+        return mMenu;
+    }
+
+    /*
+    @Deprecated
+    private int findMenuItem(int bottomSheetItemsStart,int menuItemPosition) {
+        int menuItemPosIter=-1;
+        SubMenu subMenu;
+
+        for (int i=bottomSheetItemsStart;i<mItems.size();++i) {
+            if (mItems.get(i) instanceof BottomSheetHeader) {
+                if (++menuItemPosIter==menuItemPosition) {
+                    if (i-1>-1 &&  mItems.get(i-1) instanceof BottomSheetDivider)
+                        i--;
+                    return i;
+                }
+                else if (mMenu.getItem(menuItemPosIter).hasSubMenu()) {
+                    i=i+mMenu.getItem(menuItemPosIter).getSubMenu().size();
+                }
+                else {
+                    throw new IllegalStateException("BottomSheet header should have submenu.");
+                }
+            }
+            else if (mItems.get(i) instanceof BottomSheetMenuItem) {
+                 if (++menuItemPosIter==menuItemPosition)
+                        return i;
+                }
+            }
+        return mItems.size();
+    }
+
+    @Deprecated
+    private int findMenuItem(int bottomSheetItemsStart,MenuItem item) {
+        int menuItemPosIter=-1;
+
+        for (int i=bottomSheetItemsStart;i<mItems.size();++i) {
+            if (mItems.get(i) instanceof BottomSheetHeader) {
+                if (mMenu.getItem(++menuItemPosIter)==item) {
+                    if (i-1>-1 && mItems.get(i-1) instanceof BottomSheetDivider)
+                        i--;
+                    return i;
+                }
+                else if (mMenu.getItem(menuItemPosIter).hasSubMenu()) {
+                    SubMenu subMenu=mMenu.getItem(menuItemPosIter).getSubMenu();
+                    for (int j=i;j<i+subMenu.size();++j)
+                        if (subMenu.getItem(j)==item) {
+                            searchIsSubItemFlag=true;
+                            subItemPos=menuItemPosIter;
+                            return j;
+                        }
+                    i=i+subMenu.size();
+                }
+                else {
+                    throw new IllegalStateException("BottomSheet header should have submenu.");
+                }
+            }
+            else if (mItems.get(i) instanceof BottomSheetMenuItem) {
+                if (mMenu.getItem(++menuItemPosIter)==item)
+                    return i;
+            }
+        }
+        return mItems.size();
+    }
+
+    @Deprecated
+    private int normalizePoition(int position) {
+        if (position<0)
+            return 0;
+        else if (position>=mMenu.size())
+            return mMenu.size();
+        else
+            return position;
+    }*/
+
+}

--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetHeader.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetHeader.java
@@ -16,21 +16,21 @@
 
 package com.github.rubensousa.bottomsheetbuilder.adapter;
 
-import android.support.annotation.ColorRes;
+import android.support.annotation.ColorInt;
 
 class BottomSheetHeader implements BottomSheetItem {
 
     private String mTitle;
 
-    @ColorRes
+    @ColorInt
     private int mTextColor;
 
-    public BottomSheetHeader(String title, @ColorRes int color) {
+    public BottomSheetHeader(String title, @ColorInt int color) {
         mTitle = title;
         mTextColor = color;
     }
 
-    @ColorRes
+    @ColorInt
     public int getTextColor() {
         return mTextColor;
     }

--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetItemAdapter.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetItemAdapter.java
@@ -17,6 +17,8 @@
 package com.github.rubensousa.bottomsheetbuilder.adapter;
 
 import android.content.res.ColorStateList;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewCompat;
 import android.support.v7.widget.AppCompatImageView;
@@ -149,9 +151,15 @@ class BottomSheetItemAdapter extends RecyclerView.Adapter<BottomSheetItemAdapter
         }
 
         public void setData(BottomSheetDivider item) {
-            int background = item.getBackground();
-            if (background != 0) {
-                divider.setBackgroundResource(background);
+            Drawable background = item.getBackground();
+            if (background != null) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                    divider.setBackground(background);
+                }
+                else {
+                    //noinspection deprecation
+                    divider.setBackgroundDrawable(background);
+                }
             }
         }
     }
@@ -170,7 +178,7 @@ class BottomSheetItemAdapter extends RecyclerView.Adapter<BottomSheetItemAdapter
             int color = item.getTextColor();
 
             if (color != 0) {
-                textView.setTextColor(ContextCompat.getColor(itemView.getContext(), color));
+                textView.setTextColor(color);
             }
         }
     }
@@ -192,14 +200,19 @@ class BottomSheetItemAdapter extends RecyclerView.Adapter<BottomSheetItemAdapter
             imageView.setImageDrawable(item.getIcon());
             textView.setText(item.getTitle());
             int color = item.getTextColor();
-            int background = item.getBackground();
+            Drawable background = item.getBackground();
 
             if (color != 0) {
-                textView.setTextColor(ContextCompat.getColor(itemView.getContext(), color));
+                textView.setTextColor(color);
             }
 
-            if (background != 0) {
-                itemView.setBackgroundResource(background);
+            if (background != null) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                    itemView.setBackground(background);
+                }
+                else
+                    //noinspection deprecation
+                    itemView.setBackgroundDrawable(background);
             }
 
         }

--- a/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetMenuItem.java
+++ b/library/src/main/java/com/github/rubensousa/bottomsheetbuilder/adapter/BottomSheetMenuItem.java
@@ -18,6 +18,7 @@ package com.github.rubensousa.bottomsheetbuilder.adapter;
 
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
+import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
 import android.support.v4.graphics.drawable.DrawableCompat;
@@ -33,13 +34,12 @@ class BottomSheetMenuItem implements BottomSheetItem {
     private int mId;
     private MenuItem mMenuItem;
 
-    @ColorRes
+    @ColorInt
     private int mTextColor;
 
-    @DrawableRes
-    private int mBackground;
+    private Drawable mBackground;
 
-    public BottomSheetMenuItem(MenuItem item, @ColorRes int textColor, @DrawableRes int background,
+    public BottomSheetMenuItem(MenuItem item, @ColorInt int textColor, Drawable background,
                                int tintColor) {
         mMenuItem = item;
         mIcon = item.getIcon();
@@ -63,8 +63,7 @@ class BottomSheetMenuItem implements BottomSheetItem {
         return mMenuItem;
     }
 
-    @DrawableRes
-    public int getBackground() {
+    Drawable getBackground() {
         return mBackground;
     }
 
@@ -72,7 +71,7 @@ class BottomSheetMenuItem implements BottomSheetItem {
         return mId;
     }
 
-    @ColorRes
+    @ColorInt
     public int getTextColor() {
         return mTextColor;
     }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -18,6 +18,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".RuntimeEditing"
+            android:label="@string/title_activity_runtime_editing"
+            android:theme="@style/AppTheme.NoActionBar"/>
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/github/rubensousa/bottomsheetbuilder/sample/BottomSheetViewHolder.java
+++ b/sample/src/main/java/com/github/rubensousa/bottomsheetbuilder/sample/BottomSheetViewHolder.java
@@ -1,0 +1,7 @@
+package com.github.rubensousa.bottomsheetbuilder.sample;
+
+import com.github.rubensousa.bottomsheetbuilder.adapter.BottomSheetEditor;
+
+interface BottomSheetViewHolder {
+    BottomSheetEditor getEditor();
+}

--- a/sample/src/main/java/com/github/rubensousa/bottomsheetbuilder/sample/MainActivity.java
+++ b/sample/src/main/java/com/github/rubensousa/bottomsheetbuilder/sample/MainActivity.java
@@ -1,6 +1,7 @@
 package com.github.rubensousa.bottomsheetbuilder.sample;
 
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.AppBarLayout;
@@ -242,6 +243,13 @@ public class MainActivity extends AppCompatActivity implements BottomSheetItemCl
             }
         });
         mBottomSheetDialog.show();
+    }
+
+    @SuppressWarnings("unused")
+    @OnClick(R.id.showRuntimeEditBtn)
+    public void onShowRuntimeEditClick() {
+        Intent intent=new Intent(this,RuntimeEditing.class);
+        startActivity(intent);
     }
 
     @Override

--- a/sample/src/main/java/com/github/rubensousa/bottomsheetbuilder/sample/RuntimeEditing.java
+++ b/sample/src/main/java/com/github/rubensousa/bottomsheetbuilder/sample/RuntimeEditing.java
@@ -1,0 +1,419 @@
+package com.github.rubensousa.bottomsheetbuilder.sample;
+
+import android.content.Context;
+import android.support.design.widget.BottomSheetBehavior;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.design.widget.TabLayout;
+import android.support.v4.content.res.ResourcesCompat;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.view.menu.MenuBuilder;
+import android.support.v7.widget.Toolbar;
+
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.NumberPicker;
+import android.widget.Spinner;
+
+import com.github.rubensousa.bottomsheetbuilder.BottomSheetBuilder;
+import com.github.rubensousa.bottomsheetbuilder.BottomSheetView;
+import com.github.rubensousa.bottomsheetbuilder.adapter.BottomSheetEditor;
+import com.github.rubensousa.bottomsheetbuilder.adapter.BottomSheetItemClickListener;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+
+public class RuntimeEditing extends AppCompatActivity implements AdapterView.OnItemSelectedListener, BottomSheetViewHolder,BottomSheetItemClickListener{
+    /**
+     * The {@link android.support.v4.view.PagerAdapter} that will provide
+     * fragments for each of the sections. We use a
+     * {@link FragmentPagerAdapter} derivative, which will keep every
+     * loaded fragment in memory. If this becomes too memory intensive, it
+     * may be best to switch to a
+     * {@link android.support.v4.app.FragmentStatePagerAdapter}.
+     */
+
+    /**
+     * The {@link ViewPager} that will host the section contents.
+     */
+    private ViewPager mSettingsViewPager;
+    private Spinner mSpinner;
+    private CoordinatorLayout mCoord;
+    private BottomSheetView mBottomSheet;
+    private Menu mMenu;
+    private SettingsSectionAdapter mAdapter;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_runtime_editing);
+
+        ButterKnife.bind(this);
+
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setDisplayShowTitleEnabled(false);
+
+        // Set up the ViewPager with the sections adapter.
+        mSettingsViewPager = (ViewPager) findViewById(R.id.viewpager_settings);
+        mAdapter=new SettingsSectionAdapter(getSupportFragmentManager());
+        mSettingsViewPager.setAdapter(mAdapter);
+        ((TabLayout)findViewById(R.id.tablayout_bs)).setupWithViewPager(mSettingsViewPager);
+
+        mSpinner = (Spinner) findViewById(R.id.spinner_nav);
+        List<String> items=new ArrayList<>();
+        items.add("List");
+        items.add("Grid");
+
+
+        // Creating adapter for mSpinner
+        ArrayAdapter<String> dataAdapter = new ArrayAdapter<String>(this, R.layout.textview_spinner, items);
+
+        // Drop down layout style - list view with radio button
+        dataAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+
+        // attaching data adapter to mSpinner
+        mSpinner.setAdapter(dataAdapter);
+        mSpinner.setOnItemSelectedListener(this);
+
+        mCoord= (CoordinatorLayout) findViewById(R.id.coord_bs);
+    }
+
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // Inflate the menu; this adds items to the action bar if it is present.
+        getMenuInflater().inflate(R.menu.menu_runtime_editing, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        // Handle action bar item clicks here. The action bar will
+        // automatically handle clicks on the Home/Up button, so long
+        // as you specify a parent activity in AndroidManifest.xml.
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                break;
+            case R.id.action_settings:
+                return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+        String item=adapterView.getSelectedItem().toString();
+
+        if (mBottomSheet!=null)
+            mCoord.removeView(mBottomSheet);
+
+        int mode;
+        mMenu=new MenuBuilder(this);
+        if (item=="List") {
+            new MenuInflater(this).inflate(R.menu.menu_bottom_headers_sheet_runtime,mMenu);
+            mode=BottomSheetBuilder.MODE_LIST;
+        }
+        else {
+            mode=BottomSheetBuilder.MODE_GRID;
+            new MenuInflater(this).inflate(R.menu.menu_bottom_grid_sheet_runtime,mMenu);
+        }
+        mBottomSheet=new BottomSheetBuilder(getBaseContext(),mCoord)
+                .setMenu(mMenu)
+                .setMode(mode)
+                .setBackgroundColor(android.R.color.white)
+                .setEditorEnabled(true)
+                .setItemClickListener((BottomSheetItemClickListener) RuntimeEditing.this)
+                .createView();
+        mBottomSheet.getBehavior().setSkipCollapsed(true);
+        mBottomSheet.getBehavior().setHideable(true);
+        mBottomSheet.getBehavior().setState(BottomSheetBehavior.STATE_EXPANDED);
+        mBottomSheet.getEditor().setComparator(new Comparator<MenuItem>() {
+            @Override
+            public int compare(MenuItem menuItem, MenuItem t1) {
+                return menuItem.getTitle().toString().compareTo(t1.getTitle().toString())==0?0:-1;
+            }
+        });
+    }
+
+    @Override
+    public void onNothingSelected(AdapterView<?> adapterView) {
+
+    }
+
+    @OnClick(R.id.expand)
+    public void onBottomSheetExpandBtnClick(Button button) {
+        if (mBottomSheet!=null)
+            mBottomSheet.getBehavior().setState(BottomSheetBehavior.STATE_EXPANDED);
+    }
+
+    @Override
+    public BottomSheetEditor getEditor() {
+        return mBottomSheet==null?null:mBottomSheet.getEditor();
+    }
+
+    @Override
+    public void onBottomSheetItemClick(MenuItem item) {
+        mAdapter.onMenuItemClick(item);
+    }
+
+    /**
+     * A placeholder fragment containing a simple view.
+     */
+    public static class AddPlaceholderFragment extends Fragment {
+        @BindView(R.id.add_numberPicker)
+        NumberPicker mPicker;
+
+        @BindView(R.id.add_title)
+        EditText mAddTitle;
+
+        public AddPlaceholderFragment() {
+        }
+        public static AddPlaceholderFragment newInstance() {
+            AddPlaceholderFragment fragment = new AddPlaceholderFragment();
+            return fragment;
+        }
+
+        @Override
+        public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                                 Bundle savedInstanceState) {
+            View rootView = inflater.inflate(R.layout.fragment_add, container, false);
+            ButterKnife.bind(this,rootView);
+            mPicker.setMaxValue(10);
+            return rootView;
+        }
+
+        private BottomSheetViewHolder mHolder;
+
+        @Override
+        public void onAttach(Context context) {
+            super.onAttach(context);
+            mHolder=(BottomSheetViewHolder) context;
+        }
+
+        @OnClick(R.id.button_add_menu)
+        public void onMenuAddBtnClick() {
+            Menu menu=new MenuBuilder(getContext());
+            MenuItem item=menu.add(Menu.NONE,(int)(Math.random()*Integer.MAX_VALUE),Menu.NONE,mAddTitle.getText())
+            .setIcon(ResourcesCompat.getDrawable(getResources(), android.R.drawable.ic_menu_add, null));
+            try {
+                mHolder.getEditor().addItem(item, mPicker.getValue());
+            }
+            catch (Exception e) {
+                new AlertDialog.Builder(getContext())
+                        .setTitle("Wrong input")
+                        .setMessage(e.getMessage())
+                        .setIcon(android.R.drawable.ic_dialog_alert)
+                        .show();
+            }
+        }
+
+        @OnClick(R.id.button_add_submenu)
+        public void onSubMenuAddBtnClick() {
+            Menu menu=new MenuBuilder(getContext());
+            menu.addSubMenu(Menu.NONE,(int)(Math.random()*Integer.MAX_VALUE),Menu.NONE,mAddTitle.getText());
+            try {
+                mHolder.getEditor().addItem(menu.getItem(0));
+            }
+            catch (Exception e) {
+                new AlertDialog.Builder(getContext())
+                        .setTitle("Wrong input")
+                        .setMessage(e.getMessage())
+                        .setIcon(android.R.drawable.ic_dialog_alert)
+                        .show();
+            }
+        }
+    }
+
+    /**
+     * A placeholder fragment containing a simple view.
+     */
+    public static class ChangePlaceholderFragment extends Fragment {
+        public ChangePlaceholderFragment() {
+        }
+
+        @BindView(R.id.editText_change_from)
+        EditText mFrom;
+
+        @BindView(R.id.editText_change_to)
+        EditText mTo;
+
+        /**
+         * Returns a new instance of this fragment for the given section
+         * number.
+         */
+        public static ChangePlaceholderFragment newInstance() {
+            ChangePlaceholderFragment fragment = new ChangePlaceholderFragment();
+            return fragment;
+        }
+
+        @Override
+        public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                                 Bundle savedInstanceState) {
+            View rootView = inflater.inflate(R.layout.fragment_change, container, false);
+            ButterKnife.bind(this,rootView);
+            return rootView;
+        }
+
+        private BottomSheetViewHolder mHolder;
+
+        @Override
+        public void onAttach(Context context) {
+            super.onAttach(context);
+            mHolder=(BottomSheetViewHolder) context;
+        }
+
+        @OnClick(R.id.button_change)
+        public void onChangeBtnClick() {
+            Menu menu=new MenuBuilder(getContext());
+            MenuItem item=menu.add(Menu.NONE,(int)(Math.random()*Integer.MAX_VALUE),Menu.NONE,mFrom.getText());
+            try {
+                mHolder.getEditor().changeItem(item, mTo.getText().toString());
+            }
+            catch (Exception e) {
+                new AlertDialog.Builder(getContext())
+                        .setTitle("Wrong input")
+                        .setMessage(e.getMessage())
+                        .setIcon(android.R.drawable.ic_dialog_alert)
+                        .show();
+            }
+        }
+
+        void onMenuItemClick(MenuItem item) {
+            if(mFrom!=null) mFrom.setText(item.getTitle());
+        }
+    }
+
+    /**
+     * A placeholder fragment containing a simple view.
+     */
+    public static class DeletePlaceholderFragment extends Fragment {
+
+        @BindView(R.id.editText_delete)
+        EditText mDeleteTitle;
+
+
+        public DeletePlaceholderFragment() {
+        }
+
+        /**
+         * Returns a new instance of this fragment for the given section
+         * number.
+         */
+        public static DeletePlaceholderFragment newInstance() {
+            DeletePlaceholderFragment fragment = new DeletePlaceholderFragment();
+            return fragment;
+        }
+
+        @Override
+        public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                                 Bundle savedInstanceState) {
+            View rootView = inflater.inflate(R.layout.fragment_delete, container, false);
+            ButterKnife.bind(this,rootView);
+            return rootView;
+        }
+
+        private BottomSheetViewHolder mHolder;
+
+        @Override
+        public void onAttach(Context context) {
+            super.onAttach(context);
+            mHolder=(BottomSheetViewHolder) context;
+        }
+
+        @OnClick(R.id.button_delete)
+        public void onDeleteBtnClick() {
+            Menu menu=new MenuBuilder(getContext());
+            MenuItem item=menu.add(mDeleteTitle.getText());
+            try {
+                mHolder.getEditor().removeItem(item);
+            }
+            catch (Exception e) {
+                new AlertDialog.Builder(getContext())
+                        .setTitle("Wrong input")
+                        .setMessage(e.getMessage())
+                        .setIcon(android.R.drawable.ic_dialog_alert)
+                        .show();
+            }
+        }
+
+        void onMenuItemClick(MenuItem item) {
+            if (mDeleteTitle!=null) mDeleteTitle.setText(item.getTitle());
+        }
+    }
+
+    /**
+     * A {@link FragmentPagerAdapter} that returns a fragment corresponding to
+     * one of the sections/tabs/pages.
+     */
+    public class SettingsSectionAdapter extends FragmentPagerAdapter {
+        private DeletePlaceholderFragment mDelete =DeletePlaceholderFragment.newInstance();
+        private ChangePlaceholderFragment mChange=ChangePlaceholderFragment.newInstance();
+
+        public SettingsSectionAdapter(FragmentManager fm) {
+            super(fm);
+
+        }
+
+        @Override
+        public Fragment getItem(int position) {
+            // getItem is called to instantiate the fragment for the given page.
+            // Return a AddPlaceholderFragment (defined as a static inner class below).
+            switch (position) {
+                case 0:
+                    return AddPlaceholderFragment.newInstance();
+                case 1:
+                    return mChange;
+                case 2:
+                    return mDelete;
+            }
+            return null;
+        }
+
+        @Override
+        public int getCount() {
+            // Show 3 total pages.
+            return 3;
+        }
+
+        @Override
+        public CharSequence getPageTitle(int position) {
+            switch (position) {
+                case 0:
+                    return "Add";
+                case 1:
+                    return "Change";
+                case 2:
+                    return "Delete";
+            }
+            return null;
+        }
+
+        void onMenuItemClick(MenuItem item) {
+            mDelete.onMenuItemClick(item);
+            mChange.onMenuItemClick(item);
+        }
+    }
+}

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -38,10 +38,16 @@
             android:text="Dialog with submenus" />
 
         <Button
-            android:id="@+id/showDialogGridBtn"
+        android:id="@+id/showDialogGridBtn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Dialog with a grid" />
+
+        <Button
+            android:id="@+id/showRuntimeEditBtn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Dialog with a grid" />
+            android:text="Runtime editing" />
 
     </LinearLayout>
 

--- a/sample/src/main/res/layout/activity_runtime_editing.xml
+++ b/sample/src/main/res/layout/activity_runtime_editing.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main_content"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context=".RuntimeEditing">
+
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/appbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/appbar_padding_top"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/AppTheme.PopupOverlay">
+            <Spinner
+                android:id="@+id/spinner_nav"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
+        </android.support.v7.widget.Toolbar>
+        <android.support.design.widget.TabLayout
+            android:id="@+id/tablayout_bs"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+
+    </android.support.design.widget.AppBarLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+        <android.support.v4.view.ViewPager
+            android:id="@+id/viewpager_settings"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="15" />
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:padding="0dp"
+            android:background="@color/colorPrimary"/>
+        <android.support.design.widget.CoordinatorLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:id="@+id/coord_bs"
+            android:layout_weight="40">
+            <Button
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Expand"
+                android:id="@+id/expand"
+                android:layout_gravity="bottom"/>
+        </android.support.design.widget.CoordinatorLayout>
+    </LinearLayout>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/sample/src/main/res/layout/fragment_add.xml
+++ b/sample/src/main/res/layout/fragment_add.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Add menu"
+        android:id="@+id/button_add_menu"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true" />
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Add submenu"
+        android:padding="5dp"
+        android:id="@+id/button_add_submenu"
+        android:layout_alignParentBottom="true"
+        android:layout_alignRight="@+id/add_title"
+        android:layout_alignEnd="@+id/add_title" />
+
+    <EditText
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/add_title"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
+        android:layout_below="@+id/textView2"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/menu_item_id_title"
+        android:textSize="25sp"
+        android:id="@+id/textView2"
+        android:gravity="center|clip_vertical"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:layout_toStartOf="@+id/button_add_submenu"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true" />
+
+    <NumberPicker
+        android:layout_width="wrap_content"
+        android:layout_height="50dp"
+        android:id="@+id/add_numberPicker"
+        android:layout_alignBottom="@+id/button_add_submenu"
+        android:layout_centerHorizontal="true"
+        android:solidColor="@color/colorPrimary">
+
+    </NumberPicker>
+
+</RelativeLayout>

--- a/sample/src/main/res/layout/fragment_change.xml
+++ b/sample/src/main/res/layout/fragment_change.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Change"
+        android:id="@+id/button_change"
+        android:layout_centerVertical="true"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true" />
+
+    <EditText
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/editText_change_from"
+        android:layout_below="@+id/textView_from"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:layout_alignRight="@+id/textView_from"
+        android:layout_alignEnd="@+id/textView_from" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/menu_item_id_title"
+        android:textSize="25sp"
+        android:id="@+id/textView_from"
+        android:gravity="center|clip_vertical"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:layout_toLeftOf="@+id/button_change"
+        android:layout_toStartOf="@+id/button_change" />
+
+    <EditText
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/editText_change_to"
+        android:layout_alignParentBottom="true"
+        android:layout_alignRight="@+id/textView_from"
+        android:layout_alignEnd="@+id/textView_from"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true" />
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/imageView2"
+        android:src="@android:drawable/arrow_down_float"
+        android:layout_alignRight="@+id/editText_change_from"
+        android:layout_alignEnd="@+id/editText_change_from"
+        android:layout_below="@+id/editText_change_from"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true" />
+
+
+</RelativeLayout>

--- a/sample/src/main/res/layout/fragment_delete.xml
+++ b/sample/src/main/res/layout/fragment_delete.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal">
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_weight="4"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="5"
+            android:text="@string/menu_item_id_title"
+            android:textSize="25sp"
+            android:id="@+id/textView_delete"
+            android:gravity="center|clip_vertical"/>
+        <EditText
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="3"
+            android:id="@+id/editText_delete"/>
+    </LinearLayout>
+    <Button
+        android:layout_width="0dp"
+        android:layout_weight="2"
+        android:layout_height="match_parent"
+        android:id="@+id/button_delete"
+        android:text="Delete"/>
+</LinearLayout>

--- a/sample/src/main/res/layout/fragment_runtime_editing.xml
+++ b/sample/src/main/res/layout/fragment_runtime_editing.xml
@@ -1,0 +1,16 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context=".RuntimeEditing$AddPlaceholderFragment">
+
+    <TextView
+        android:id="@+id/section_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+</RelativeLayout>

--- a/sample/src/main/res/layout/textview_spinner.xml
+++ b/sample/src/main/res/layout/textview_spinner.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:textColor="@android:color/white"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:gravity="center_vertical"
+    android:textSize="25sp"/>

--- a/sample/src/main/res/menu/menu_bottom_grid_sheet_runtime.xml
+++ b/sample/src/main/res/menu/menu_bottom_grid_sheet_runtime.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:icon="@drawable/ic_gmail_48dp"
+        android:title="Gmail"
+        android:id="@+id/id_1"/>
+    <item
+        android:icon="@drawable/ic_hangouts_48dp"
+        android:title="Hangouts"
+        android:id="@+id/id_2"/>
+    <item
+        android:icon="@drawable/ic_google_48dp"
+        android:title="Google+"
+        android:id="@+id/id_3"/>
+    <item
+        android:icon="@drawable/ic_mail_48dp"
+        android:title="Mail"
+        android:id="@+id/id_4"/>
+
+    <item
+        android:icon="@drawable/ic_message_48dp"
+        android:title="Message"
+        android:id="@+id/id_5"/>
+
+    <item
+        android:icon="@drawable/ic_content_copy_48dp"
+        android:title="Copy"
+        android:id="@+id/id_6"/>
+
+    <item
+        android:icon="@drawable/ic_facebook_box"
+        android:title="Facebook"
+        android:id="@+id/id_7"/>
+
+    <item
+        android:icon="@drawable/ic_twitter_box"
+        android:title="Twitter"
+        android:id="@+id/id_8"/>
+
+</menu>

--- a/sample/src/main/res/menu/menu_bottom_headers_sheet_runtime.xml
+++ b/sample/src/main/res/menu/menu_bottom_headers_sheet_runtime.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:title="Create"
+        android:id="@+id/id_0">
+        <menu>
+            <item
+                android:icon="@drawable/ic_document"
+                android:title="Document"
+                android:id="@+id/id_1"/>
+            <item
+                android:icon="@drawable/ic_spreadsheet"
+                android:title="Spreadsheet"
+                android:id="@+id/id_2"/>
+            <item
+                android:icon="@drawable/ic_folder_24dp"
+                android:title="Folder"
+                android:id="@+id/id_3"/>
+        </menu>
+    </item>
+
+
+    <item android:title=""
+        android:id="@+id/id_4">
+        <menu>
+            <item
+                android:icon="@drawable/ic_cloud_upload_24dp"
+                android:title="Upload photos or videos"
+                android:id="@+id/id_5"/>
+            <item
+                android:icon="@drawable/ic_camera_alt_24dp"
+                android:title="Use Camera"
+                android:id="@+id/id_6"/>
+        </menu>
+    </item>
+
+
+</menu>

--- a/sample/src/main/res/menu/menu_runtime_editing.xml
+++ b/sample/src/main/res/menu/menu_runtime_editing.xml
@@ -1,0 +1,10 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".RuntimeEditing">
+    <item
+        android:id="@+id/action_settings"
+        android:orderInCategory="100"
+        android:title="@string/action_settings"
+        app:showAsAction="never" />
+</menu>

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#3F51B5</color>
+    <color name="colorPrimary">#3f51b5</color>
     <color name="colorPrimaryDark">#303F9F</color>
     <color name="colorAccent">#FF4081</color>
 </resources>

--- a/sample/src/main/res/values/dimens.xml
+++ b/sample/src/main/res/values/dimens.xml
@@ -3,4 +3,5 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="fab_margin">16dp</dimen>
+    <dimen name="appbar_padding_top">8dp</dimen>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <resources>
     <string name="app_name">BottomSheetBuilder</string>
     <string name="action_settings">Settings</string>
+    <string name="title_activity_runtime_editing">RuntimeEditing</string>
+    <string name="menu_item_id_title">Menu item title</string>
 </resources>


### PR DESCRIPTION
It should be compatible with older versions, because so far `BottomSheetAdapterBuilder` returned a view, but now it returns `BottomSheetView` which is a linear layout and it encapsulates the old one but also adds `BottomSheetEditor`. The editor is able to change the menu hierarchy. Meaning that it can add `MenuItem` (it can have submenu),remove `MenuItem` (with submenu) or change one `MenuItem`. Due to some limitations of `Menu` in android it cannot add them to a specific position, yet. Changed `BottomSheetBuilder` to not store any item information that the `BottomSheetEditor` might need, because the builder will be destroyed. Instead `BottomSheetAdapterBuilder` stores all the needed informations. `BottomSheetEditor`'s code a little bit messy because i wanted to change as few classes as possible.