### PR TITLE
Use text size from the Material design guideline

### DIFF
--- a/bottomsheetbuilder/src/main/res/values/dimens.xml
+++ b/bottomsheetbuilder/src/main/res/values/dimens.xml
@@ -9,7 +9,7 @@
     <dimen name="bottomsheet_vertical_margin">8dp</dimen>
     <dimen name="bottomsheet_elevation">16dp</dimen>
     <dimen name="bottomsheet_title_size">16sp</dimen>
-    <dimen name="bottomsheet_item_textsize">18sp</dimen>
+    <dimen name="bottomsheet_item_textsize">16sp</dimen>
 
     <bool name="landscape">false</bool>
     <bool name="tablet_landscape">false</bool>


### PR DESCRIPTION
According to the spec, text and title should be both 16sp
https://material.io/guidelines/components/bottom-sheets.html#bottom-sheets-specs