### PR TITLE
Long strings truncated wrongly

### DIFF
--- a/bottomsheetbuilder/src/main/res/layout/bottomsheetbuilder_grid_adapter.xml
+++ b/bottomsheetbuilder/src/main/res/layout/bottomsheetbuilder_grid_adapter.xml
@@ -21,6 +21,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_marginTop="4dp"
+        android:singleLine="true"
         android:ellipsize="end"
         android:maxLines="1"
         android:textSize="12sp"

--- a/bottomsheetbuilder/src/main/res/layout/bottomsheetbuilder_list_adapter.xml
+++ b/bottomsheetbuilder/src/main/res/layout/bottomsheetbuilder_list_adapter.xml
@@ -25,6 +25,7 @@
         android:layout_marginLeft="@dimen/bottomsheet_horizontal_margin"
         android:layout_marginStart="@dimen/bottomsheet_horizontal_margin"
         android:ellipsize="end"
+        android:singleLine="true"
         android:maxLines="1"
         android:gravity="center_vertical"
         android:textSize="@dimen/bottomsheet_item_textsize"


### PR DESCRIPTION
Before: 

![Before](https://user-images.githubusercontent.com/4923871/35917723-6a330cce-0c0f-11e8-956f-a2cf87dd626a.png) 

After:

![After](https://user-images.githubusercontent.com/4923871/35917724-6c3d77f2-0c0f-11e8-8493-809a3edd5884.png)

It is known android bug when `ellipsize` works as expected only when `singleLine = true`
